### PR TITLE
Add FastAPI REST API for MLP model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app app
+
+ENV MODEL_DIR=/app/model
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# MLP Risk Classification API
+
+This repository provides a FastAPI service that exposes a trained MLP model for
+risk classification.
+
+## Build and run with Docker
+
+1. Place the trained TensorFlow model directory (`mlp_tf_model`) and
+   `mlp_tf_pipeline.pkl` inside a folder on your host.
+2. Build the container:
+   ```bash
+   docker build -t mlp-api .
+   ```
+3. Run the service, mounting the folder with the model artifacts:
+   ```bash
+   docker run -p 8000:8000 -v /path/to/artifacts:/app/model mlp-api
+   ```
+4. Send a prediction request:
+   ```bash
+   curl -X POST "http://localhost:8000/predict" -H "Content-Type: application/json" \
+        -d '{"sexo": "M", "glosa_red": "diagnostico", "edad_al_hospitalizarse": 40,
+             "plan_para_asegurados": "plan1", "plan_catastrofico_asegurado": "no",
+             "estado_vigencia_cobertura": "activa", "prestacion_basica": "si",
+             "cto_dto": 123.0}'
+   ```
+
+The service will respond with the predicted risk class and probabilities for
+each class.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,71 @@
+"""FastAPI application to serve MLP risk classification model."""
+from pathlib import Path
+import os
+from typing import Optional
+
+import joblib
+import pandas as pd
+import tensorflow as tf
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+# Directory containing model artifacts. Can be overridden via MODEL_DIR env var.
+MODEL_DIR = Path(os.getenv("MODEL_DIR", "."))
+
+app = FastAPI(title="MLP Risk Classifier API")
+
+# Globals for the loaded artifacts
+model: Optional[tf.keras.Model] = None
+preprocessor = None
+scaler = None
+label_encoder = None
+
+
+class PatientFeatures(BaseModel):
+    """Input data for prediction."""
+    sexo: str
+    glosa_red: str
+    edad_al_hospitalizarse: float
+    plan_para_asegurados: str
+    plan_catastrofico_asegurado: str
+    estado_vigencia_cobertura: str
+    prestacion_basica: str
+    cto_dto: float
+
+
+@app.on_event("startup")
+def load_artifacts() -> None:
+    """Load model and preprocessing artifacts into memory."""
+    global model, preprocessor, scaler, label_encoder
+    model_path = MODEL_DIR / "mlp_tf_model"
+    pipeline_path = MODEL_DIR / "mlp_tf_pipeline.pkl"
+    if not model_path.exists() or not pipeline_path.exists():
+        raise RuntimeError(
+            "Model or pipeline not found. Set MODEL_DIR to directory containing"
+            " 'mlp_tf_model' and 'mlp_tf_pipeline.pkl'."
+        )
+    model = tf.keras.models.load_model(model_path)
+    pipeline = joblib.load(pipeline_path)
+    preprocessor = pipeline["preprocessor"]
+    scaler = pipeline["scaler"]
+    label_encoder = pipeline["label_encoder"]
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Simple health check endpoint."""
+    return {"status": "ok"}
+
+
+@app.post("/predict")
+async def predict(features: PatientFeatures) -> dict[str, object]:
+    """Predict risk level for a patient."""
+    if model is None:
+        raise HTTPException(status_code=503, detail="Model not loaded")
+    data = pd.DataFrame([features.dict()])
+    tX = preprocessor.transform(data)
+    tX = scaler.transform(tX)
+    probs = model.predict(tX)
+    pred_idx = int(probs.argmax(axis=1)[0])
+    label = label_encoder.inverse_transform([pred_idx])[0]
+    return {"prediction": label, "probabilities": probs[0].tolist()}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn[standard]
+tensorflow
+scikit-learn
+pandas
+joblib


### PR DESCRIPTION
## Summary
- add FastAPI app exposing MLP model with prediction endpoint
- containerize service with Dockerfile and add runtime requirements
- document how to build and run the API

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688ebe649a908331a722dd384db7f298